### PR TITLE
vim-nodejs-errorformat update

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -9,6 +9,7 @@ let &makeprg="node %"
 "     at Object.foo [as _onTimeout] (/Users/Felix/.vim/bundle/vim-nodejs-errorformat/test.js:2:9)
 let &errorformat  = '%AError: %m' . ','
 let &errorformat .= '%AReferenceError: %m' . ','
+let &errorformat .= '%Z%*[\ ]at\ %f:%l:%c' . ','
 let &errorformat .= '%Z%*[\ ]%m (%f:%l:%c)' . ','
 
 "     at Object.foo [as _onTimeout] (/Users/Felix/.vim/bundle/vim-nodejs-errorformat/test.js:2:9)

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -8,15 +8,19 @@ let &makeprg="node %"
 " Error: bar
 "     at Object.foo [as _onTimeout] (/Users/Felix/.vim/bundle/vim-nodejs-errorformat/test.js:2:9)
 let &errorformat  = '%AError: %m' . ','
+let &errorformat .= '%AReferenceError: %m' . ','
 let &errorformat .= '%Z%*[\ ]%m (%f:%l:%c)' . ','
 
 "     at Object.foo [as _onTimeout] (/Users/Felix/.vim/bundle/vim-nodejs-errorformat/test.js:2:9)
 let &errorformat .= '%*[\ ]%m (%f:%l:%c)' . ','
 
+"     at node.js:903:3
+let &errorformat .= '%*[\ ]at\ %f:%l:%c' . ','
+
 " /Users/Felix/.vim/bundle/vim-nodejs-errorformat/test.js:2
 "   throw new Error('bar');
 "         ^
-let &errorformat .= '%A%f:%l,%Z%p%m' . ','
+let &errorformat .= '%Z%p^,%A%f:%l,%C%m' . ','
 
 " Ignore everything else
 let &errorformat .= '%-G%.%#'
@@ -37,7 +41,7 @@ function! HookCoreFilesIntoQuickfixWindow()
         " Clear all previous buffer contents
         execute ':1,%d'
         " Load the node.js core file (thanks @izs for pointing this out!)
-        execute 'read !node -e "process.binding(\"natives\").' expand('%:r') '"'
+        silent! execute 'read !node -e "console.log(process.binding(\"natives\").' expand('%:r') ')"'
         " Delete the first line, always empty for some reason
         execute ':1d'
         " Tell vim to treat this buffer as a JS file


### PR DESCRIPTION
This is the first time I am requesting a new pull, so let me know if I missed something.

The error message generated by this code was not being parsed correctly:

function foo() {
    throw new Error('bar');
}
foo();

Nor this one: (this one generates a ReferenceError)

a[123456] = 123

Also I was not able to open the "native" files, not sure what might have changed recently but outputting with console.log works for me.

Tested in a Mac OS X 10.8.3

Change log:
Updated error format to parse ReferenceError
Fixed a bug when an exception was thrown in the "main" function
Fixed reading internal node files
