### PR TITLE
Bugfix: plugin not working for files outside cwd

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -46,7 +46,7 @@ function! HookCoreFilesIntoQuickfixWindow()
         " Clear all previous buffer contents
         execute ':1,%d'
         " Load the node.js core file (thanks @izs for pointing this out!)
-        silent! execute 'read !node -e "console.log(process.binding(\"natives\").' expand('%:r') ')"'
+        silent! execute 'read !node -e "console.log(process.binding(\"natives\").' expand('%:t:r') ')"'
         " Delete the first line, always empty for some reason
         execute ':1d'
         " Tell vim to treat this buffer as a JS file


### PR DESCRIPTION
When running a file outside vim's current working directory, `expand('%:r')` will inculde relative directory path.
e.g. If I run vim in `/home/me` and execute `:e myproject/abc.js`, `expand('%:r')` will become `"myproject/abc"` rather than `"abc"`. The node expression will then become `process.binding("natives").myproject/abc` which will not execute properly.

Replacing `expand('%:r')` with `expand('%:t:r')` should fix this problem.